### PR TITLE
Add callback for promise cancellation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,11 +8,13 @@ type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never;
 // see https://stackoverflow.com/a/54825370/82609
 export function onlyResolvesLast<T extends (...args: any[]) => any>(
   asyncFunction: T,
+  onCancel?: () => void
 ): T {
   let cancelPrevious: CancelCallback | null = null;
 
   const wrappedFunction = (...args: ArgumentsType<T>) => {
     cancelPrevious && cancelPrevious();
+    cancelPrevious && onCancel && onCancel();
     const initialPromise = asyncFunction(...args);
     const { promise, cancel } = createImperativePromise(initialPromise);
     cancelPrevious = cancel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,8 @@ export function onlyResolvesLast<T extends (...args: any[]) => any>(
   let promisePrevious: ReturnType<typeof makeQueryablePromise>;
 
   const wrappedFunction = (...args: ArgumentsType<T>) => {
+    promisePrevious && promisePrevious.isPending && promisePrevious.isPending() && onCancel && onCancel();
     cancelPrevious && cancelPrevious();
-    promisePrevious && promisePrevious.isPending && !promisePrevious.isPending() && onCancel && onCancel();
     const initialPromise = asyncFunction(...args);
     const { promise, cancel } = createImperativePromise(initialPromise);
     cancelPrevious = cancel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,24 +1,54 @@
-import {
-  createImperativePromise,
-  CancelCallback,
-} from 'awesome-imperative-promise';
+import { CancelCallback, createImperativePromise } from 'awesome-imperative-promise';
 
 type ArgumentsType<T> = T extends (...args: infer A) => any ? A : never;
+
+type PromiseQueryType<T> = T & { isRejected?: () => boolean, isFulfilled?: () => boolean, isPending?: () => boolean };
+
+function makeQueryablePromise<T>(promise: PromiseQueryType<Promise<T>>): PromiseQueryType<Promise<T>> {
+  // Don't modify any promise that has been already modified.
+  if (promise.isPending) return promise;
+
+  // Set initial state
+  let isPending = true;
+  let isRejected = false;
+  let isFulfilled = false;
+
+  // Observe the promise, saving the fulfillment in a closure scope.
+  const result: PromiseQueryType<Promise<T>> = promise.then(
+    (v) => {
+      isFulfilled = true;
+      isPending = false;
+      return v;
+    },(e) => {
+      isRejected = true;
+      isPending = false;
+      throw e;
+    }
+  );
+
+  result.isFulfilled = () => isFulfilled;
+  result.isPending = () => isPending;
+  result.isRejected = () => isRejected;
+
+  return result;
+}
 
 // see https://stackoverflow.com/a/54825370/82609
 export function onlyResolvesLast<T extends (...args: any[]) => any>(
   asyncFunction: T,
-  onCancel?: () => void
+  onCancel?: () => void,
 ): T {
   let cancelPrevious: CancelCallback | null = null;
+  let promisePrevious: ReturnType<typeof makeQueryablePromise>;
 
   const wrappedFunction = (...args: ArgumentsType<T>) => {
     cancelPrevious && cancelPrevious();
-    cancelPrevious && onCancel && onCancel();
+    promisePrevious && promisePrevious.isPending && !promisePrevious.isPending() && onCancel && onCancel();
     const initialPromise = asyncFunction(...args);
     const { promise, cancel } = createImperativePromise(initialPromise);
     cancelPrevious = cancel;
-    return promise;
+    promisePrevious = makeQueryablePromise(promise);
+    return promisePrevious;
   };
 
   return wrappedFunction as any; // TODO fix TS


### PR DESCRIPTION
I need to be notified if a promise is not going through as I usually use .finally from the promise but, if it is cancelled, that does not work.

Please let me know if this is an appropriate change or if it should be solved in a different way.